### PR TITLE
photosonly flavor

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Build photos APK with Gradle
       run: ./gradlew assemblePhotosDebug
 
+    - name: Build photosonly APK with Gradle
+      run: ./gradlew assemblePhotosonlyDebug
+
     - name: Upload APKs
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ the [changelog](https://grapheneos.org/releases#2023040400):
 > services
 
 Before that, back in July 2021, GrapheneOS implemented a compatibility layer to use the original Google Play services
-without advanced permissions. For Gcam it was sufficient to install the Google Service Framework (GSF). 
-
-> [!CAUTION]
-> If you already use the Sandboxed Play services or plan to use it in future, you cannot use the Gcam Services
-> Provider for technical reasons. **This limitation applies beyond the boundaries of a user profile.**
+without advanced permissions. For Gcam it was sufficient to install the Google Service Framework (GSF).
 
 ### Comparison: [microG](https://github.com/microg)
 
@@ -40,10 +36,10 @@ access).
 > [!IMPORTANT]
 > Using GrapheneOS? Make sure you read the comparison with *GrapheneOS' Gcam support* above!
 
-Currently there are two versions of this app named "basic" and "photos". "Basic" includes everything you need to get
+There are three versions of this app named "basic", "photos", and "photosonly". "Basic" includes everything you need to get
 Gcam running but the button showing the last taken photo in full size will not work. The "photos" version has all
 features from "basic" and adds support for this button but you cannot have the Google Photos app installed for technical
-reasons.
+reasons. The "photosonly" version adds support for this button without a shim for GSF; it is meant to be used on GrapheneOS alongside the sandboxed Play Services.
 
 Note that this app comes without UI and therefore has no icon in the app drawer. But of course it is listed in the
 Android settings (e.g. for uninstallation).
@@ -52,6 +48,7 @@ Android settings (e.g. for uninstallation).
 |----------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Basic version  | - Google Service Framework (GSF)<br/>- microg                     | [GitHub](https://github.com/lukaspieper/Gcam-Services-Provider/releases)<br/>[F-Droid](https://f-droid.org/de/packages/de.lukaspieper.gcam.services/) |
 | Photos version | - Google Service Framework (GSF)<br/>- microg<br/>- Google Photos | [GitHub](https://github.com/lukaspieper/Gcam-Services-Provider/releases)                                                                              |
+| Photosonly version | - microg<br/>- Google Photos | [GitHub](https://github.com/lukaspieper/Gcam-Services-Provider/releases) |
 
 ### Gcam Compatibility
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,10 @@ android {
             dimension 'default'
             applicationId 'com.google.android.apps.photos'
         }
+        photosonly {
+            dimension 'default'
+            applicationId 'com.google.android.apps.photos'
+        }
     }
 
     // No benefit outside of Google Play, disabled for IzzyOnDroid

--- a/app/src/photosonly/AndroidManifest.xml
+++ b/app/src/photosonly/AndroidManifest.xml
@@ -1,0 +1,51 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:forceQueryable="true"
+        android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.NoDisplay"
+        tools:targetApi="30">
+
+        <provider
+            android:name="de.lukaspieper.gcam.GServicesProvider"
+            android:authorities="com.google.android.gsf.gservices"
+            android:exported="true"
+            tools:ignore="ExportedContentProvider"
+            tools:node="remove" />  <!-- remove this provider for the photosonly flavor -->
+
+        <activity
+            android:name="de.lukaspieper.gcam.PreviewRedirectActivity"
+            android:exported="true">
+
+            <!-- Credits to Calyx developers: -->
+            <!-- https://gitlab.com/CalyxOS/platform_external_calyx_GCamPhotosPreview -->
+            <intent-filter>
+                <action android:name="com.android.camera.action.REVIEW" />
+                <action android:name="android.provider.action.REVIEW" />
+                <action android:name="android.provider.action.REVIEW_SECURE" />
+                <action android:name="com.google.android.apps.photos.mars.api.ACTION_REVIEW" />
+                <action android:name="com.google.android.apps.photos.mars.api.ACTION_REVIEW_SECURE" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="content" />
+
+                <data android:mimeType="image/*" />
+                <data android:mimeType="video/*" />
+                <data android:mimeType="application/vnd.google.panorama360+jpg" />
+            </intent-filter>
+
+            <!-- Needed only so GCam can query for and find us -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+        </activity>
+
+    </application>
+</manifest>


### PR DESCRIPTION
This adds a build without the shim `GServicesProvider` for use alongside sandboxed Play Services.

closes #116